### PR TITLE
Fix XML namespace duplication and decouple cost from flow distance

### DIFF
--- a/aas_xml.py
+++ b/aas_xml.py
@@ -71,8 +71,6 @@ def write_aas_production_plans(
     output_path: str,
 ) -> None:
     env = ET.Element(f"{{{NS_AAS}}}environment")
-    env.set("xmlns:aas", NS_AAS)
-    env.set("xmlns:xs", NS_XS)
 
     shells = ET.SubElement(env, f"{{{NS_AAS}}}assetAdministrationShells")
     shell = ET.SubElement(shells, f"{{{NS_AAS}}}assetAdministrationShell")

--- a/gnn_rl_pipeline.py
+++ b/gnn_rl_pipeline.py
@@ -920,7 +920,7 @@ def write_production_plans(assignments: List[Tuple[str,str]], template: str|None
 # 예시 저장 (템플릿 없으면 None)
 OUTPUT_XML = os.path.join(os.path.dirname(MBOM_PATH), "ProductionPlans.xml")
 write_production_plans(assignments, template=None, output=OUTPUT_XML)
-topk_results = rollout_topk_with_rl(env, agent, k=10)
+topk_results = rollout_topk_with_rl(env, agent, k=10, use_flow_as_cost=False)
 plans_for_aas = [(plan, flow) for _, flow, plan in topk_results]
 out_aas_xml = os.path.join(os.path.dirname(MBOM_PATH), "ProductionPlans_AAS.xml")
 write_aas_production_plans(plans_for_aas, df_proc, df_aas, out_aas_xml)


### PR DESCRIPTION
## Summary
- avoid duplicate namespace declarations in AAS XML generator
- treat RL cost separately from material-flow distance

## Testing
- `python -m py_compile aas_xml.py gnn_rl_pipeline.py`
- `pip install pandas` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a47fbdf6848323a78955e613aa8001