### PR TITLE
feat: visualize flow with road routes

### DIFF
--- a/gnn_rl_pipeline.py
+++ b/gnn_rl_pipeline.py
@@ -860,11 +860,12 @@ def visualize_material_flow(plan: List[Tuple[str, str]], env, output_html: str):
             continue
         i = id_to_idx[leg["from_fac"]]
         j = id_to_idx[leg["to_fac"]]
+        path_coords = provider.pair_path(
+            float(env.fac_lat[i]), float(env.fac_lon[i]),
+            float(env.fac_lat[j]), float(env.fac_lon[j])
+        )
         folium.PolyLine(
-            [
-                (float(env.fac_lat[i]), float(env.fac_lon[i])),
-                (float(env.fac_lat[j]), float(env.fac_lon[j])),
-            ],
+            path_coords,
             weight=4,
             tooltip=f"{leg['label']} ~ {km:.2f} km"
         ).add_to(m)


### PR DESCRIPTION
## Summary
- add `pair_path` to `KakaoDirectionsProvider` to fetch road path coordinates from Kakao Mobility Directions API with a straight-line fallback
- update material flow visualization to draw polylines along road routes instead of straight lines

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a496f49ea483239851ffa9319ee6f5