### PR TITLE
Enforce Kakao API key for road routing

### DIFF
--- a/gnn_rl_pipeline.py
+++ b/gnn_rl_pipeline.py
@@ -154,7 +154,12 @@ df_aas, failed_files = parse_aas_folder(AAS_DIR)
 # =========================================================
 # 3) Geocoding (Kakao) + address cleaning
 # =========================================================
-KAKAO_API_KEY = "ac473e33b35d06d474e45ab59d2b69d0"  # TODO: put your key
+KAKAO_API_KEY = os.getenv("KAKAO_API_KEY", "")
+if not KAKAO_API_KEY:
+    raise RuntimeError(
+        "KAKAO_API_KEY 환경 변수가 설정되지 않았습니다. "
+        "경로 계산을 위해 유효한 Kakao API 키를 등록하세요."
+    )
 def clean_address(addr: str) -> str:
     if addr is None or pd.isna(addr): return ""
     s = str(addr).strip()
@@ -250,7 +255,7 @@ def haversine(lat1, lon1, lat2, lon2):
     a = np.sin(dlat/2)**2 + np.cos(np.radians(lat1))*np.cos(np.radians(lat2))*np.sin(dlon/2)**2
     return R*2*np.arctan2(np.sqrt(a), np.sqrt(1-a))
 
-provider = KakaoDirectionsProvider()
+provider = KakaoDirectionsProvider(api_key=KAKAO_API_KEY)
 
 # fac↔fac KNN travel edges
 K = max(1, min(5, len(fac)-1))

--- a/kakao_directions.py
+++ b/kakao_directions.py
@@ -75,9 +75,10 @@ class KakaoDirectionsProvider:
         if cached is not None:
             return cached
         if not self.api_key:
-            km = _haversine(lat1, lon1, lat2, lon2)
-            minutes = (km / 40.0) * 60.0
-            return km, minutes
+            raise RuntimeError(
+                "Kakao API 키가 설정되지 않았습니다. 환경 변수 KAKAO_API_KEY를 설정하거나 "
+                "KakaoDirectionsProvider(api_key=...)로 전달하세요."
+            )
         url = "https://apis-navi.kakaomobility.com/v1/directions"
         headers = {
             "Authorization": f"KakaoAK {self.api_key}",
@@ -118,7 +119,10 @@ class KakaoDirectionsProvider:
                   max_retries: int = 3) -> List[Tuple[float, float]]:
         """도로 경로 좌표열을 반환한다. 실패 시 직선으로 폴백."""
         if not self.api_key:
-            return [(lat1, lon1), (lat2, lon2)]
+            raise RuntimeError(
+                "Kakao API 키가 설정되지 않아 도로 경로를 계산할 수 없습니다. "
+                "환경 변수 KAKAO_API_KEY를 설정하거나 KakaoDirectionsProvider(api_key=...)로 전달하세요."
+            )
         url = "https://apis-navi.kakaomobility.com/v1/directions"
         headers = {
             "Authorization": f"KakaoAK {self.api_key}",


### PR DESCRIPTION
## Summary
- Read `KAKAO_API_KEY` from env and fail fast when missing
- Pass API key to `KakaoDirectionsProvider`
- Raise runtime error in `KakaoDirectionsProvider` if API key absent

## Testing
- `python -m py_compile kakao_directions.py gnn_rl_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4a2ac51788323b1bc87da2536de67