### PR TITLE
Fix DataFrame row join in gnn pipeline

### DIFF
--- a/gnn_rl_pipeline.py
+++ b/gnn_rl_pipeline.py
@@ -235,7 +235,7 @@ lon = fac["Longitude"].astype(float).to_numpy()
 fac_type = pd.Series("미분류", index=fac.index, dtype=str)
 if "ManufacturerName" in fac.columns:
     fac_type[fac["ManufacturerName"].astype(str).str.strip().eq("건솔루션")] = "조립"
-TXT = fac.fillna("").astype(str).apply(lambda s: " ".join(s), axis=1).str.upper()
+TXT = fac.fillna("").astype(str).agg(" ".join, axis=1).str.upper()
 MAP = {
     "적층제조": r"(FDM|PBF|3D\s*PRINT|적층|ADDITIVE)",
     "절삭"   : r"(CNC|MILL|밀링|선반|LATHE|절삭|다이캐스팅|MACHINING|머시닝)",


### PR DESCRIPTION
## Summary
- avoid AttributeError when joining DataFrame rows by using `agg(" ".join, axis=1)` before calling `.str.upper()`

## Testing
- `python gnn_rl_pipeline.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ab7199208323ac2223037e880f37